### PR TITLE
k8s環境の作成と，アプリケーションのデプロイ

### DIFF
--- a/kind-cluster.yaml
+++ b/kind-cluster.yaml
@@ -1,0 +1,13 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+# 1 control plane node and 3 workers
+nodes:
+# the control plane node config
+- role: control-plane
+  extraPortMappings:
+    - containerPort: 30599
+      hostPort: 8080
+# the three workers
+- role: worker
+- role: worker
+- role: worker

--- a/kubernetes/app-deployment.yaml
+++ b/kubernetes/app-deployment.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app-deployment
+  labels:
+    app: app
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: app
+  template:
+    metadata:
+      labels:
+        app: app
+    spec:
+      containers:
+      - name: app-container
+        image: ghcr.io/static-fuji/lab-quiz-app:1.0.0
+        ports:
+        - containerPort: 8080
+        env:
+        - name: TODO_ENV
+          value: "dev"
+        - name: PORT
+          value: "8080"
+        - name: TODO_DB_HOST
+          value: "db-service"
+        - name: TODO_DB_PORT
+          value: "3306"
+        - name: TODO_DB_USER
+          value: "todo"
+        - name: TODO_DB_PASSWORD
+          value: "todo"
+        - name: TODO_DB_DATABASE
+          value: "todo"

--- a/kubernetes/app-service.yaml
+++ b/kubernetes/app-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: app-service
+spec:
+  selector:
+    app: app
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8080
+      nodePort: 30599
+  type: NodePort

--- a/kubernetes/db-deployment.yaml
+++ b/kubernetes/db-deployment.yaml
@@ -1,0 +1,47 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: db-deployment
+  labels:
+    app: db
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: db
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      containers:
+      - name: db-container
+        image: mysql:8.0.29
+        ports:
+        - containerPort: 3306
+        env:
+        - name: MYSQL_ALLOW_EMPTY_PASSWORD
+          value: "yes"
+        - name: MYSQL_USER
+          value: "todo"
+        - name: MYSQL_PASSWORD
+          value: "todo"
+        - name: MYSQL_DATABASE
+          value: "todo"
+        volumeMounts:
+        - name: mysql-data
+          mountPath: /var/lib/mysql
+        - name: mysql-config
+          mountPath: /etc/mysql/conf.d
+        - name: init-script
+          mountPath: /docker-entrypoint-initdb.d
+      volumes:
+      - name: mysql-data
+        persistentVolumeClaim:
+          claimName: mysql-pvc
+      - name: mysql-config
+        configMap:
+          name: mysql-config
+      - name: init-script
+        configMap:
+          name: schema-config

--- a/kubernetes/db-service.yaml
+++ b/kubernetes/db-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: db-service
+spec:
+  selector:
+    app: db
+  ports:
+    - protocol: TCP
+      port: 3306
+      targetPort: 3306
+  type: ClusterIP

--- a/kubernetes/mysql-configmap.yaml
+++ b/kubernetes/mysql-configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mysql-config
+data:
+  my.cnf: |
+    [mysqld]
+    character-set-server=utf8mb4
+    datadir=/var/lib/mysql
+    socket=/var/lib/mysql/mysql.sock
+    pid-file=/var/lib/mysql/mysql.pid

--- a/kubernetes/mysql-pvc.yaml
+++ b/kubernetes/mysql-pvc.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: mysql-pv-volume # PVの名前
+  labels:
+    type: local
+spec:
+  storageClassName: manual # PVCと一致させる必要がある
+  capacity:
+    storage: 20Gi
+  accessModes:
+    - ReadWriteOnce # 一つのノードからread/writeでマウントできるモード
+  hostPath:
+    path: "/mnt/data"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: mysql-pvc
+spec:
+  # storageClassName=manualのPVを探してマウントする
+  storageClassName: manual 
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi # PVが持っている容量のうち20GBを使用する

--- a/kubernetes/schema-configmap.yaml
+++ b/kubernetes/schema-configmap.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: schema-config
+data:
+  init.sql: |
+    CREATE TABLE `user`
+    (
+        `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'ユーザの識別子',
+        `name` VARCHAR(20) NOT NULL COMMENT 'ユーザ名',
+        `password` VARCHAR(80) NOT NULL COMMENT 'パスワードハッシュ',
+        `role` VARCHAR(20) NOT NULL COMMENT 'ロール',
+        `created` DATETIME(6) NOT NULL COMMENT 'レコード作成日時',
+        `modified` DATETIME(6) NOT NULL COMMENT 'レコード修正日時',
+        PRIMARY KEY (`id`),
+        UNIQUE KEY `uix_name` (`name`) USING BTREE
+    ) Engine=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='ユーザ';
+
+    CREATE TABLE `task`
+    (
+        `id` BIGINT UNSIGNED NOT NULL AUTO_INCREMENT COMMENT 'タスクの識別子',
+        `title` VARCHAR(128) NOT NULL COMMENT 'タスクのタイトル',
+        `status` VARCHAR(20) NOT NULL COMMENT 'タスクの状態',
+        `created` DATETIME(6) NOT NULL COMMENT 'レコード作成日時',
+        `modified` DATETIME(6) NOT NULL COMMENT 'レコード修正日時',
+        PRIMARY KEY (`id`)
+    ) Engine=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='タスク';


### PR DESCRIPTION
## 概要

過去にハンズオンで作成したtodoアプリケーションを，k8sにデプロイした
## 変更点

- docker-composeによるコンテナ管理を取りやめた
- Dockerfileのdev stageでdocker imageを作成
- `ghcr.io/static-fuji/lab-quiz-app`にアプリケーションのdocker imageをpush
- docker-composeの設定を参考に，アプリケーション，dbそれぞれのデプロイメント，サービスのマニフェストを作成
- dbの設定，スキーマをconfigmapに記載

## 影響範囲

アプリケーション，dbへの影響は無い
## 関連Issue

- 関連Issue: #2 
